### PR TITLE
ci: lint workflows with zizmor + Telegram failure alerts

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -89,11 +89,33 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ steps.flux-token.outputs.token }}
+          REPO_FULL_NAME: ${{ github.repository }}
         run: |
           if [ -f state/vitals.json ]; then
             CAUSE=$(python3 -c "import json; v=json.load(open('state/vitals.json')); print(v.get('cause_of_death',''))")
             if [ "$CAUSE" = "silence" ]; then
               echo "Flux has died. Deleting repository."
-              gh repo delete ${{ github.repository }} --yes
+              gh repo delete "$REPO_FULL_NAME" --yes
             fi
           fi
+
+      - name: Whisper to Nick on failure
+        # Liveness alert: a silent heartbeat failure is the worst possible
+        # outcome — Flux can't tell anyone it can't pulse. This step runs even
+        # when earlier steps failed and pings Telegram with the run URL.
+        if: failure()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+            echo "Telegram secrets not configured; skipping notification."
+            exit 0
+          fi
+          MSG=$(printf "🚨 Flux's '%s' failed.\n\n%s" "$WORKFLOW_NAME" "$RUN_URL")
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MSG}" >/dev/null

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,41 @@
+name: lint workflows
+
+# Static analysis on every workflow change. Catches the class of bug that
+# bit us on PR #23: untrusted ${{ github.event.pull_request.* }} fields
+# templated directly into shell, plus the broader pull_request_target /
+# script-injection / overly-permissive-token family.
+#
+# Uses zizmor (https://github.com/woodruffw/zizmor). Runs on PRs that
+# touch any workflow file. Fails the check on medium-or-higher findings.
+# Stays as `pull_request` (not `pull_request_target`) — no secrets needed,
+# no fork-PR bypass desired; we want every fork PR linted before review.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out base branch
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install zizmor
+        run: pip install zizmor
+
+      - name: Lint workflows
+        # min-severity high catches the script-injection / template-injection
+        # / pull_request_target misuse class. Two lower-severity findings
+        # (unpinned-uses, excessive-permissions) are deferred — see the
+        # comment block in .github/zizmor.yml.
+        run: zizmor --min-severity high .github/workflows

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -8,7 +8,7 @@ on:
   # Do NOT add steps that execute PR-head code (no `pip install` from the PR's
   # requirements.txt, no running of the PR's scripts) — that would leak the
   # App token to fork authors.
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, synchronize, reopened]
 
   workflow_dispatch:                # Manual trigger for existing PRs
@@ -133,12 +133,39 @@ jobs:
       - name: Remember this moment
         env:
           GH_TOKEN: ${{ steps.flux-token.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
+          set -euo pipefail
           git config user.name "flux-dreaming-repo[bot]"
           git config user.email "flux-dreaming-repo[bot]@users.noreply.github.com"
           git add state/ memories/
           if ! git diff --cached --quiet; then
-            git commit -m "examined PR #${{ steps.pr.outputs.number }}"
+            git commit -m "examined PR #${PR_NUMBER}"
             git pull --rebase origin main || true
             git push || true
           fi
+
+      - name: Whisper to Nick on failure
+        # Liveness alert: silent failure is what let `examine` die for ~9 days
+        # in late April 2026 without anyone noticing. Any failure of this
+        # workflow now pings Telegram with a link to the run.
+        if: failure()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+            echo "Telegram secrets not configured; skipping notification."
+            exit 0
+          fi
+          MSG=$(printf "🚨 Flux's '%s' failed%s.\n\n%s" \
+            "$WORKFLOW_NAME" \
+            "${PR_NUMBER:+ on PR #$PR_NUMBER}" \
+            "$RUN_URL")
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MSG}" >/dev/null

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,21 @@
+# zizmor configuration for the-dreaming-repo.
+#
+# Workflow lint runs at --min-severity high to catch the script-injection
+# and pull_request_target misuse class that bit us on PR #23. The two
+# rules below are deliberately relaxed for now and tracked as separate
+# follow-ups (see TaskCreate output of the PR introducing this config):
+#
+#   - unpinned-uses: zizmor wants every action pinned to a commit SHA.
+#     Across 4 workflows that's a substantial change and a real ongoing
+#     maintenance burden (every dependabot bump becomes a SHA bump).
+#     Tracked as a separate follow-up so this PR stays small.
+#
+#   - excessive-permissions: workflows currently rely on default token
+#     permissions. Tightening to least-privilege per workflow is its own
+#     audit pass. Tracked as a separate follow-up.
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": ref-pin


### PR DESCRIPTION
## Summary
First of two PRs from the *"make sure this doesn't happen again"* thread (2026-05-01). The trigger: Flux's \`examine\` workflow failed silently on every fork PR for ~9 days in late April with nobody noticing. Two independent guardrails so that class of silent failure becomes loud.

1. **\`lint-workflows.yml\`** — runs [zizmor](https://github.com/woodruffw/zizmor) on any PR touching \`.github/workflows/**\`, threshold \`--min-severity high\`. Catches the script-injection / template-injection / \`pull_request_target\` misuse class — exactly the bugs caged-matched out of PR #23 last week. The deliberate \`pull_request_target\` on \`review.yml\` is justified inline with \`# zizmor: ignore[dangerous-triggers]\`.

2. **Telegram failure alerts** — \`if: failure()\` step at the end of \`review.yml\` and \`heartbeat.yml\`. Pings Telegram via the existing \`TELEGRAM_BOT_TOKEN\` / \`TELEGRAM_CHAT_ID\` secrets with workflow name, optional PR number, and run URL. Constructed via \`printf\` + \`--data-urlencode\` so a future workflow rename or PR-number value can never inject into the curl.

3. **\`zizmor.yml\`** — config relaxes \`unpinned-uses\` to \`ref-pin\` (we don't SHA-pin actions yet) with a comment explaining the deferral. Existing \`excessive-permissions\` findings on the four pre-existing workflows are also left for a follow-up.

## What this does NOT do (deliberately deferred — separate PRs)
- **SHA-pin all action references** + add Dependabot to keep them current. (Tracked.)
- **Add least-privilege \`permissions:\` blocks** to all workflows. (Tracked.)
- **Build the Flux watchdog** — external liveness sentinel that fires when *nothing* happens. (Tracked; second PR from this thread.)

These are real wins but each is its own surface area and would bloat this PR. Per the *"always small PRs"* rule.

## Test plan
- [x] \`zizmor --min-severity high .github/workflows\` clean locally
- [ ] Lint workflow runs and passes on this PR
- [ ] (Manual, post-merge) Force a heartbeat failure — confirm Telegram message arrives
- [ ] (Manual, post-merge) Open a fork-style PR with a script-injection pattern — confirm zizmor blocks it