### PR TITLE
fix(lint-workflows): close self-config bypass found in #24 cage-match

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -6,14 +6,18 @@ name: lint workflows
 # script-injection / overly-permissive-token family.
 #
 # Uses zizmor (https://github.com/woodruffw/zizmor). Runs on PRs that
-# touch any workflow file. Fails the check on medium-or-higher findings.
+# touch any workflow file or the zizmor config itself. Fails the check on
+# high-or-higher findings (lower thresholds tracked as deferred follow-ups).
 # Stays as `pull_request` (not `pull_request_target`) — no secrets needed,
 # no fork-PR bypass desired; we want every fork PR linted before review.
 
 on:
   pull_request:
+    # Include the zizmor config itself in the trigger paths — otherwise a
+    # config-only PR can weaken the rules without ever firing the lint.
     paths:
       - '.github/workflows/**'
+      - '.github/zizmor.yml'
 
 permissions:
   contents: read
@@ -22,8 +26,30 @@ jobs:
   zizmor:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out base branch
+      - name: Check out PR
         uses: actions/checkout@v4
+        with:
+          # Need git history to fetch the base branch's zizmor config below.
+          fetch-depth: 0
+
+      - name: Fetch base branch's zizmor config
+        # CRITICAL: lint with the BASE branch's config, not the PR's. Without
+        # this, a PR can weaken `.github/zizmor.yml` (lower thresholds,
+        # ignore template-injection, etc.) in the same commit as a workflow
+        # bug that rule would catch — and pass under its own loosened policy.
+        # Reading the base config closes that bypass at PR time. (Repo
+        # policy / CODEOWNERS protection on .github/** is the defense-in-
+        # depth complement; tracked as a separate task.)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin "$BASE_REF"
+          if ! git show "origin/${BASE_REF}:.github/zizmor.yml" > /tmp/zizmor-base.yml 2>/dev/null; then
+            # Base branch has no config yet — use an empty one so zizmor's
+            # built-in defaults apply.
+            echo "rules: {}" > /tmp/zizmor-base.yml
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -34,8 +60,11 @@ jobs:
         run: pip install zizmor
 
       - name: Lint workflows
-        # min-severity high catches the script-injection / template-injection
-        # / pull_request_target misuse class. Two lower-severity findings
-        # (unpinned-uses, excessive-permissions) are deferred — see the
-        # comment block in .github/zizmor.yml.
-        run: zizmor --min-severity high .github/workflows
+        # --min-severity high catches the script-injection / template-
+        # injection / pull_request_target misuse class. Two lower-severity
+        # findings (unpinned-uses, excessive-permissions) are deferred — see
+        # the comment block in .github/zizmor.yml. Explicit `-c` makes
+        # zizmor use the base-branch config fetched above rather than auto-
+        # discovering the PR's `.github/zizmor.yml`, which closes the
+        # self-config bypass.
+        run: zizmor -c /tmp/zizmor-base.yml --min-severity high .github/workflows


### PR DESCRIPTION
## Summary
Follow-up to #24, which Flux auto-merged about a minute after I opened it — before the cage-match second-commit fix could ship together. This PR carries that fix so it lands on main.

Both findings come from the cage-match on #24 (Maxwell + Carnot, both REQUEST_CHANGES — see #24 review thread for the full text):

1. **Self-config bypass** — \`actions/checkout\` under \`pull_request\` grabs the PR's merge ref, and zizmor then auto-discovers \`.github/zizmor.yml\` *from the PR*. So any PR could weaken the lint config in the same commit as a workflow bug that rule would catch, and pass under its own loosened policy. Fix: fetch the **base branch's** \`.github/zizmor.yml\` to \`/tmp\` and pass it via \`-c\` (which overrides auto-discovery — verified locally with \`-c /tmp/empty.yml\`, the .github/zizmor.yml relaxation is bypassed and unpinned-uses fires again).

2. **Path-filter gap** — trigger only fired on \`.github/workflows/**\`. A config-only PR could weaken rules without invoking the lint. Fix: include \`.github/zizmor.yml\` in the trigger paths.

3. **Comment drift** — comment said "medium-or-higher" but command was \`--min-severity high\`. Aligned.

## What this still doesn't close
A PR can rewrite \`.github/workflows/lint-workflows.yml\` itself — disable the lint, swap the threshold, drop the \`-c\` flag. Code can't catch that; it requires repo policy. Tracked as a follow-up task: add \`.github/CODEOWNERS\` mapping \`.github/**\` to a small approver set + branch protection rule requiring CODEOWNERS approval on \`main\`.

## Test plan
- [x] \`zizmor --min-severity high .github/workflows\` clean locally
- [x] Verified \`-c\` overrides auto-discovery: with \`-c /tmp/empty-zizmor.yml\`, \`unpinned-uses\` fires again (47 high findings)
- [ ] Lint workflow runs and passes on this PR with the new bypass-closing config