### PR TITLE
feat: add watchdog workflow for liveness monitoring

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -37,9 +37,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read     # Read vitals.json via Contents API
-  issues: write      # Open/update the watchdog issue
-  actions: read      # `gh run list` for examine health
+  contents: read         # Read vitals.json via Contents API
+  issues: write          # Open/update the watchdog issue
+  actions: read          # workflow-runs API for examine health
+  pull-requests: read    # `gh pr list` + review data for staleness check
 
 concurrency:
   group: watchdog
@@ -51,6 +52,7 @@ jobs:
     steps:
       - name: Heartbeat liveness check
         id: heartbeat
+        continue-on-error: true  # aggregate step inspects outcome and alarms
         env:
           GH_TOKEN: ${{ github.token }}
           REPO_FULL_NAME: ${{ github.repository }}
@@ -97,43 +99,59 @@ jobs:
 
       - name: Examine health check
         id: examine
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO_FULL_NAME: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Last 10 review.yml runs.
-          RUNS=$(gh run list \
-            --repo "$REPO_FULL_NAME" \
-            --workflow=review.yml \
-            --limit 10 \
-            --json conclusion,createdAt,headBranch,headRepository,event,url)
+          # Most recent review.yml runs. We hit the REST API directly
+          # rather than `gh run list --json` because the latter does NOT
+          # expose head_repository, and we need it for fork-PR detection.
+          #
+          # per_page=30 (not 10): the failure-rate metric still uses the
+          # most recent 10 (line below), but the fork-fail-in-24h check
+          # needs to see the full 24h window — on a busy day the 11th
+          # run can still be inside 24h and would be missed at per_page=10.
+          # 30 is a comfortable upper bound for 24h of examine activity
+          # on this repo without paginating.
+          RUNS_RAW=$(gh api \
+            "repos/${REPO_FULL_NAME}/actions/workflows/review.yml/runs?per_page=30" \
+            --jq '[.workflow_runs[] | {
+              conclusion,
+              created_at,
+              head_branch,
+              event,
+              url: .html_url,
+              head_repo_full_name: (.head_repository.full_name // null)
+            }]')
 
-          TOTAL=$(printf '%s' "$RUNS" | jq 'length')
+          # Failure rate is computed over the most recent 10 runs only —
+          # spec says "10 runs", and a 24h window of failure-rate would
+          # over- or under-sample depending on activity bursts.
+          RECENT=$(printf '%s' "$RUNS_RAW" | jq '[.[]] | .[0:10]')
+          TOTAL=$(printf '%s' "$RECENT" | jq 'length')
           if [ "$TOTAL" -eq 0 ]; then
             echo "No examine runs found; skipping."
             echo "alarm=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          FAILED=$(printf '%s' "$RUNS" | jq '[.[] | select(.conclusion == "failure")] | length')
+          FAILED=$(printf '%s' "$RECENT" | jq '[.[] | select(.conclusion == "failure")] | length')
           # Integer percent, no bc dependency.
           RATE=$(( FAILED * 100 / TOTAL ))
           echo "Examine: ${FAILED}/${TOTAL} failures (${RATE}%)"
 
-          # Fork-PR failure in last 24h. A run is from a fork if its
-          # headRepository differs from the repo running this workflow.
-          # (gh exposes headRepository.owner.login + name.)
+          # Fork-PR failure in last 24h. A run is from a fork iff its
+          # head_repo_full_name differs from this repo (or is null, which
+          # the API returns when the head repo has been deleted — treat
+          # that as suspicious too).
           CUTOFF=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || python3 -c "import datetime; print((datetime.datetime.utcnow() - datetime.timedelta(hours=24)).strftime('%Y-%m-%dT%H:%M:%SZ'))")
-          REPO_OWNER="${REPO_FULL_NAME%/*}"
-          REPO_NAME="${REPO_FULL_NAME#*/}"
-          FORK_FAILS=$(printf '%s' "$RUNS" | jq --arg cutoff "$CUTOFF" --arg owner "$REPO_OWNER" --arg name "$REPO_NAME" '
+          FORK_FAILS=$(printf '%s' "$RUNS_RAW" | jq --arg cutoff "$CUTOFF" --arg repo "$REPO_FULL_NAME" '
             [.[]
               | select(.conclusion == "failure")
-              | select(.createdAt > $cutoff)
-              | select(.headRepository == null
-                       or (.headRepository.owner.login // "") != $owner
-                       or (.headRepository.name // "") != $name)
+              | select(.created_at > $cutoff)
+              | select(.head_repo_full_name == null or .head_repo_full_name != $repo)
             ] | length')
 
           ALARM=false
@@ -155,7 +173,7 @@ jobs:
               printf '%b' "$REASONS"
               echo ""
               echo "Recent runs:"
-              printf '%s' "$RUNS" | jq -r '.[] | "- \(.conclusion // "running")\t\(.createdAt)\t\(.headBranch)\t\(.url)"'
+              printf '%s' "$RUNS_RAW" | jq -r '.[] | "- \(.conclusion // "running")\t\(.created_at)\t\(.head_branch)\t\(.url)"'
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
           else
@@ -164,23 +182,40 @@ jobs:
 
       - name: Open-PR review staleness check
         id: pr_staleness
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO_FULL_NAME: ${{ github.repository }}
           BOT_LOGIN: flux-dreaming-repo[bot]
         run: |
           set -euo pipefail
+          # --limit 100 because gh's default (30) silently truncates and
+          # could hide a stale PR — exactly the silent-absence class of
+          # bug this whole workflow exists to catch.
           PRS=$(gh pr list \
             --repo "$REPO_FULL_NAME" \
             --state open \
-            --json number,createdAt,reviews,author,title,url)
+            --limit 100 \
+            --json number,createdAt,reviews,author,title,url,isDraft)
 
           CUTOFF=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || python3 -c "import datetime; print((datetime.datetime.utcnow() - datetime.timedelta(hours=24)).strftime('%Y-%m-%dT%H:%M:%SZ'))")
 
+          # A PR is "stale" when:
+          #   - opened > 24h ago
+          #   - is NOT a draft (drafts are explicitly WIP, not awaiting review)
+          #   - is NOT authored by the flux bot (Flux reviewing its own PR is
+          #     not the signal we want; that's a separate workflow concern)
+          #   - has no review from the flux bot (the actual examine signal)
+          # `gh pr list` reports bot logins as either "flux-dreaming-repo[bot]"
+          # or with the trailing "[bot]" stripped depending on context — we
+          # match a `login` substring to be robust against either form.
           STALE=$(printf '%s' "$PRS" | jq --arg cutoff "$CUTOFF" --arg bot "$BOT_LOGIN" '
+            def is_bot($login): ($login // "") | startswith($bot | rtrimstr("[bot]"));
             [.[]
+              | select(.isDraft == false)
               | select(.createdAt < $cutoff)
-              | select([.reviews[]?.author.login // empty] | map(. == $bot) | any | not)
+              | select(is_bot(.author.login) | not)
+              | select([.reviews[]? | select(is_bot(.author.login))] | length == 0)
             ]')
 
           COUNT=$(printf '%s' "$STALE" | jq 'length')
@@ -209,12 +244,15 @@ jobs:
           HB_ALARM: ${{ steps.heartbeat.outputs.alarm }}
           HB_SUMMARY: ${{ steps.heartbeat.outputs.summary }}
           HB_DETAIL: ${{ steps.heartbeat.outputs.detail }}
+          HB_OUTCOME: ${{ steps.heartbeat.outcome }}
           EX_ALARM: ${{ steps.examine.outputs.alarm }}
           EX_SUMMARY: ${{ steps.examine.outputs.summary }}
           EX_DETAIL: ${{ steps.examine.outputs.detail }}
+          EX_OUTCOME: ${{ steps.examine.outcome }}
           PR_ALARM: ${{ steps.pr_staleness.outputs.alarm }}
           PR_SUMMARY: ${{ steps.pr_staleness.outputs.summary }}
           PR_DETAIL: ${{ steps.pr_staleness.outputs.detail }}
+          PR_OUTCOME: ${{ steps.pr_staleness.outcome }}
         run: |
           set -euo pipefail
 
@@ -230,7 +268,24 @@ jobs:
           } > "$BODY_FILE"
 
           add_section() {
-            local name="$1" alarm="$2" summary="$3" detail="$4"
+            local name="$1" alarm="$2" summary="$3" detail="$4" outcome="$5"
+            # If the check step itself didn't succeed, treat that as an
+            # alarm — empty outputs from a failed step would otherwise
+            # silently render as "OK" (the very class of bug this
+            # workflow exists to catch). `outcome` values: success,
+            # failure, cancelled, skipped.
+            if [ "$outcome" != "success" ]; then
+              ANY=true
+              {
+                echo "## ${name}: ALARM (check step ${outcome})"
+                echo ""
+                echo "The check step itself reported outcome=${outcome};"
+                echo "treating as an alarm because we cannot prove the system is healthy."
+                echo ""
+              } >> "$BODY_FILE"
+              printf -- '- %s: check step %s\n' "$name" "$outcome" >> "$SUMMARY_FILE"
+              return
+            fi
             if [ "$alarm" = "true" ]; then
               ANY=true
               {
@@ -252,9 +307,9 @@ jobs:
             fi
           }
 
-          add_section "Heartbeat liveness" "${HB_ALARM:-false}" "${HB_SUMMARY:-}" "${HB_DETAIL:-}"
-          add_section "Examine health"     "${EX_ALARM:-false}" "${EX_SUMMARY:-}" "${EX_DETAIL:-}"
-          add_section "Open-PR review staleness" "${PR_ALARM:-false}" "${PR_SUMMARY:-}" "${PR_DETAIL:-}"
+          add_section "Heartbeat liveness"        "${HB_ALARM:-false}" "${HB_SUMMARY:-}" "${HB_DETAIL:-}" "${HB_OUTCOME:-failure}"
+          add_section "Examine health"            "${EX_ALARM:-false}" "${EX_SUMMARY:-}" "${EX_DETAIL:-}" "${EX_OUTCOME:-failure}"
+          add_section "Open-PR review staleness"  "${PR_ALARM:-false}" "${PR_SUMMARY:-}" "${PR_DETAIL:-}" "${PR_OUTCOME:-failure}"
 
           if [ "$ANY" = "false" ]; then
             echo "All checks passed; no alarms to dispatch."
@@ -264,7 +319,37 @@ jobs:
             exit 0
           fi
 
+          # ---- Telegram ping FIRST ----
+          # Telegram is the independent alerting path. Issue creation runs
+          # AFTER, so a GitHub Issues outage (or a labels API blip) can't
+          # silently suppress the notification. The Telegram message links
+          # to the run; if the issue create succeeds we update with the
+          # issue link via a follow-up edit on the next run.
+          TG_OK=skipped
+          if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+            MSG_FILE=$(mktemp)
+            {
+              printf "🐺 Watchdog alarm in %s\n\n" "$REPO_FULL_NAME"
+              cat "$SUMMARY_FILE"
+              printf "\nRun: %s\n" "$RUN_URL"
+            } > "$MSG_FILE"
+
+            if curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+                --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+                --data-urlencode "text@${MSG_FILE}" >/dev/null; then
+              TG_OK=ok
+            else
+              TG_OK=failed
+              echo "::warning::Telegram notification failed; continuing to issue update."
+            fi
+          else
+            echo "Telegram secrets not configured; skipping notification."
+          fi
+
           # ---- Find or create the watchdog issue (search by label first) ----
+          # Wrapped so that a labels-API outage doesn't take down Telegram
+          # alerting (already done above) or fail the whole workflow.
+          set +e
           EXISTING=$(gh issue list \
             --repo "$REPO_FULL_NAME" \
             --state open \
@@ -273,45 +358,34 @@ jobs:
             --json number \
             --jq '.[0].number // empty')
 
-          # Ensure the label exists. `gh label create` errors if it already
-          # exists; --force makes it idempotent.
+          # Ensure the label exists. --force makes it idempotent.
           gh label create watchdog \
             --repo "$REPO_FULL_NAME" \
             --color B60205 \
             --description "Opened by .github/workflows/watchdog.yml" \
-            --force >/dev/null 2>&1 || true
+            --force >/dev/null 2>&1
 
           if [ -n "$EXISTING" ]; then
             echo "Updating existing watchdog issue #${EXISTING}"
             gh issue edit "$EXISTING" \
               --repo "$REPO_FULL_NAME" \
               --body-file "$BODY_FILE" >/dev/null
-            ISSUE_NUM="$EXISTING"
           else
             echo "Opening new watchdog issue"
-            ISSUE_URL=$(gh issue create \
+            gh issue create \
               --repo "$REPO_FULL_NAME" \
               --title "Watchdog: liveness alarm" \
               --label watchdog \
-              --body-file "$BODY_FILE")
-            ISSUE_NUM="${ISSUE_URL##*/}"
-            echo "Opened ${ISSUE_URL}"
+              --body-file "$BODY_FILE"
           fi
+          ISSUE_RC=$?
+          set -e
 
-          # ---- Telegram ping ----
-          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
-            echo "Telegram secrets not configured; skipping notification."
+          # Final exit code: fail the run iff BOTH paths failed (Telegram
+          # was down/unconfigured AND the issue update failed). If at
+          # least one alerted, the watchdog has done its job.
+          if [ "$TG_OK" = "ok" ] || [ "$ISSUE_RC" -eq 0 ]; then
             exit 0
           fi
-
-          ISSUE_URL_FULL="${RUN_URL%/actions/runs/*}/issues/${ISSUE_NUM}"
-          MSG_FILE=$(mktemp)
-          {
-            printf "🐺 Watchdog alarm in %s\n\n" "$REPO_FULL_NAME"
-            cat "$SUMMARY_FILE"
-            printf "\nIssue: %s\nRun: %s\n" "$ISSUE_URL_FULL" "$RUN_URL"
-          } > "$MSG_FILE"
-
-          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
-            --data-urlencode "text@${MSG_FILE}" >/dev/null
+          echo "::error::Both Telegram and issue notification paths failed."
+          exit 1

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -1,0 +1,317 @@
+name: watchdog
+
+# External liveness sentinel. Counterpart to the runtime failure-alerts that
+# fire on events — the watchdog fires on ABSENCE. If something silently stops
+# happening (heartbeat hasn't pulsed, examine is failing on fork PRs, PRs are
+# sitting unreviewed) this workflow notices and shouts.
+#
+# History: in late April 2026 the heartbeat failed silently for ~9 days
+# because `examine` was broken on fork PRs and nobody noticed. PR #23 fixed
+# the auth issue; PR #24/#25 added zizmor lint + Telegram failure alerts.
+# This is the third leg — catch silent absence even when no event fires.
+#
+# Three independent checks per run; each can alarm independently:
+#   1. Heartbeat liveness — vitals.json `last_heartbeat_at` older than 90 min
+#      (3× the 30-min cron, so brief misses don't page).
+#   2. Examine health — failure rate >30% across last 10 examine runs OR any
+#      fork-PR examine failure in last 24h.
+#   3. Open-PR review staleness — PRs older than 24h with no review from the
+#      flux bot.
+#
+# Each alarm pings Telegram AND opens-or-updates a single GitHub issue
+# tagged `watchdog`. Search-by-label-first means we never spam: we edit the
+# existing issue body in place rather than opening a new one per run.
+#
+# Schedule offset from heartbeat (heartbeat: */30, watchdog: 7 * * * *) to
+# reduce correlated failure — if both ran on the same minute and GitHub
+# Actions had a region outage, we'd lose both alerting paths simultaneously.
+#
+# This workflow is `schedule` + `workflow_dispatch` only — never triggered
+# by fork PRs, so no untrusted input is ever mixed with the bot token. All
+# `${{ github.* }}` values are passed via `env:` and consumed via shell
+# variables, never templated directly into `run:` blocks (lesson from #23).
+
+on:
+  schedule:
+    - cron: '7 * * * *'  # Hourly, offset from heartbeat's */30
+  workflow_dispatch:
+
+permissions:
+  contents: read     # Read vitals.json via Contents API
+  issues: write      # Open/update the watchdog issue
+  actions: read      # `gh run list` for examine health
+
+concurrency:
+  group: watchdog
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat liveness check
+        id: heartbeat
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL_NAME: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Fetch vitals.json fresh via the Contents API rather than
+          # checking out a (potentially stale) ref. We want the actual
+          # current state of main, not a snapshot.
+          VITALS=$(gh api "repos/${REPO_FULL_NAME}/contents/state/vitals.json" \
+            --jq '.content' | base64 -d)
+
+          LAST=$(printf '%s' "$VITALS" | jq -r '.last_heartbeat_at // empty')
+          if [ -z "$LAST" ]; then
+            echo "alarm=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "summary=Heartbeat liveness: vitals.json missing last_heartbeat_at field"
+              echo "detail<<EOF"
+              echo "Could not read .last_heartbeat_at from state/vitals.json."
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Compute age in minutes. Both timestamps in UTC.
+          NOW_EPOCH=$(date -u +%s)
+          LAST_EPOCH=$(date -u -d "$LAST" +%s 2>/dev/null || python3 -c "import datetime,sys; print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))" "$LAST")
+          AGE_MIN=$(( (NOW_EPOCH - LAST_EPOCH) / 60 ))
+          echo "Last heartbeat: $LAST ($AGE_MIN min ago)"
+
+          THRESHOLD=90
+          if [ "$AGE_MIN" -gt "$THRESHOLD" ]; then
+            echo "alarm=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "summary=Heartbeat silent for ${AGE_MIN} minutes (threshold ${THRESHOLD})"
+              echo "detail<<EOF"
+              echo "Last heartbeat: ${LAST}"
+              echo "Age: ${AGE_MIN} minutes"
+              echo "Threshold: ${THRESHOLD} minutes (3× the 30-min cron)"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "alarm=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Examine health check
+        id: examine
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL_NAME: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Last 10 review.yml runs.
+          RUNS=$(gh run list \
+            --repo "$REPO_FULL_NAME" \
+            --workflow=review.yml \
+            --limit 10 \
+            --json conclusion,createdAt,headBranch,headRepository,event,url)
+
+          TOTAL=$(printf '%s' "$RUNS" | jq 'length')
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "No examine runs found; skipping."
+            echo "alarm=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FAILED=$(printf '%s' "$RUNS" | jq '[.[] | select(.conclusion == "failure")] | length')
+          # Integer percent, no bc dependency.
+          RATE=$(( FAILED * 100 / TOTAL ))
+          echo "Examine: ${FAILED}/${TOTAL} failures (${RATE}%)"
+
+          # Fork-PR failure in last 24h. A run is from a fork if its
+          # headRepository differs from the repo running this workflow.
+          # (gh exposes headRepository.owner.login + name.)
+          CUTOFF=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || python3 -c "import datetime; print((datetime.datetime.utcnow() - datetime.timedelta(hours=24)).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+          REPO_OWNER="${REPO_FULL_NAME%/*}"
+          REPO_NAME="${REPO_FULL_NAME#*/}"
+          FORK_FAILS=$(printf '%s' "$RUNS" | jq --arg cutoff "$CUTOFF" --arg owner "$REPO_OWNER" --arg name "$REPO_NAME" '
+            [.[]
+              | select(.conclusion == "failure")
+              | select(.createdAt > $cutoff)
+              | select(.headRepository == null
+                       or (.headRepository.owner.login // "") != $owner
+                       or (.headRepository.name // "") != $name)
+            ] | length')
+
+          ALARM=false
+          REASONS=""
+          if [ "$RATE" -gt 30 ]; then
+            ALARM=true
+            REASONS="${REASONS}Failure rate ${RATE}% (${FAILED}/${TOTAL}) exceeds 30% threshold.\n"
+          fi
+          if [ "$FORK_FAILS" -gt 0 ]; then
+            ALARM=true
+            REASONS="${REASONS}${FORK_FAILS} fork-PR examine failure(s) in last 24h.\n"
+          fi
+
+          if [ "$ALARM" = "true" ]; then
+            echo "alarm=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "summary=Examine health degraded (${FAILED}/${TOTAL} failed, ${FORK_FAILS} fork-PR fails 24h)"
+              echo "detail<<EOF"
+              printf '%b' "$REASONS"
+              echo ""
+              echo "Recent runs:"
+              printf '%s' "$RUNS" | jq -r '.[] | "- \(.conclusion // "running")\t\(.createdAt)\t\(.headBranch)\t\(.url)"'
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "alarm=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open-PR review staleness check
+        id: pr_staleness
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL_NAME: ${{ github.repository }}
+          BOT_LOGIN: flux-dreaming-repo[bot]
+        run: |
+          set -euo pipefail
+          PRS=$(gh pr list \
+            --repo "$REPO_FULL_NAME" \
+            --state open \
+            --json number,createdAt,reviews,author,title,url)
+
+          CUTOFF=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || python3 -c "import datetime; print((datetime.datetime.utcnow() - datetime.timedelta(hours=24)).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+
+          STALE=$(printf '%s' "$PRS" | jq --arg cutoff "$CUTOFF" --arg bot "$BOT_LOGIN" '
+            [.[]
+              | select(.createdAt < $cutoff)
+              | select([.reviews[]?.author.login // empty] | map(. == $bot) | any | not)
+            ]')
+
+          COUNT=$(printf '%s' "$STALE" | jq 'length')
+          echo "Stale PRs: ${COUNT}"
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "alarm=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "summary=${COUNT} open PR(s) older than 24h with no flux review"
+              echo "detail<<EOF"
+              printf '%s' "$STALE" | jq -r '.[] | "- #\(.number) \(.title) (by @\(.author.login), opened \(.createdAt))\n  \(.url)"'
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "alarm=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Aggregate alarms and notify
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL_NAME: ${{ github.repository }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HB_ALARM: ${{ steps.heartbeat.outputs.alarm }}
+          HB_SUMMARY: ${{ steps.heartbeat.outputs.summary }}
+          HB_DETAIL: ${{ steps.heartbeat.outputs.detail }}
+          EX_ALARM: ${{ steps.examine.outputs.alarm }}
+          EX_SUMMARY: ${{ steps.examine.outputs.summary }}
+          EX_DETAIL: ${{ steps.examine.outputs.detail }}
+          PR_ALARM: ${{ steps.pr_staleness.outputs.alarm }}
+          PR_SUMMARY: ${{ steps.pr_staleness.outputs.summary }}
+          PR_DETAIL: ${{ steps.pr_staleness.outputs.detail }}
+        run: |
+          set -euo pipefail
+
+          ANY=false
+          BODY_FILE=$(mktemp)
+          SUMMARY_FILE=$(mktemp)
+
+          {
+            echo "# Watchdog alarms"
+            echo ""
+            echo "Last run: ${RUN_URL}"
+            echo ""
+          } > "$BODY_FILE"
+
+          add_section() {
+            local name="$1" alarm="$2" summary="$3" detail="$4"
+            if [ "$alarm" = "true" ]; then
+              ANY=true
+              {
+                echo "## ${name}: ALARM"
+                echo ""
+                echo "${summary}"
+                echo ""
+                echo '```'
+                printf '%s\n' "$detail"
+                echo '```'
+                echo ""
+              } >> "$BODY_FILE"
+              printf -- '- %s: %s\n' "$name" "$summary" >> "$SUMMARY_FILE"
+            else
+              {
+                echo "## ${name}: OK"
+                echo ""
+              } >> "$BODY_FILE"
+            fi
+          }
+
+          add_section "Heartbeat liveness" "${HB_ALARM:-false}" "${HB_SUMMARY:-}" "${HB_DETAIL:-}"
+          add_section "Examine health"     "${EX_ALARM:-false}" "${EX_SUMMARY:-}" "${EX_DETAIL:-}"
+          add_section "Open-PR review staleness" "${PR_ALARM:-false}" "${PR_SUMMARY:-}" "${PR_DETAIL:-}"
+
+          if [ "$ANY" = "false" ]; then
+            echo "All checks passed; no alarms to dispatch."
+            # If a watchdog issue is open, we leave it — closing on green
+            # would mask flapping. Operators close it manually when they've
+            # acknowledged + resolved the underlying issue.
+            exit 0
+          fi
+
+          # ---- Find or create the watchdog issue (search by label first) ----
+          EXISTING=$(gh issue list \
+            --repo "$REPO_FULL_NAME" \
+            --state open \
+            --label watchdog \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty')
+
+          # Ensure the label exists. `gh label create` errors if it already
+          # exists; --force makes it idempotent.
+          gh label create watchdog \
+            --repo "$REPO_FULL_NAME" \
+            --color B60205 \
+            --description "Opened by .github/workflows/watchdog.yml" \
+            --force >/dev/null 2>&1 || true
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing watchdog issue #${EXISTING}"
+            gh issue edit "$EXISTING" \
+              --repo "$REPO_FULL_NAME" \
+              --body-file "$BODY_FILE" >/dev/null
+            ISSUE_NUM="$EXISTING"
+          else
+            echo "Opening new watchdog issue"
+            ISSUE_URL=$(gh issue create \
+              --repo "$REPO_FULL_NAME" \
+              --title "Watchdog: liveness alarm" \
+              --label watchdog \
+              --body-file "$BODY_FILE")
+            ISSUE_NUM="${ISSUE_URL##*/}"
+            echo "Opened ${ISSUE_URL}"
+          fi
+
+          # ---- Telegram ping ----
+          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+            echo "Telegram secrets not configured; skipping notification."
+            exit 0
+          fi
+
+          ISSUE_URL_FULL="${RUN_URL%/actions/runs/*}/issues/${ISSUE_NUM}"
+          MSG_FILE=$(mktemp)
+          {
+            printf "🐺 Watchdog alarm in %s\n\n" "$REPO_FULL_NAME"
+            cat "$SUMMARY_FILE"
+            printf "\nIssue: %s\nRun: %s\n" "$ISSUE_URL_FULL" "$RUN_URL"
+          } > "$MSG_FILE"
+
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text@${MSG_FILE}" >/dev/null


### PR DESCRIPTION
## Summary

Third leg of the post-mortem trio after the silent 9-day heartbeat outage:

- **PR #23** fixed `examine` auth on fork PRs (root cause)
- **PR #24/#25** added zizmor lint + Telegram failure alerts (event-driven)
- **This PR** catches silent absence — fires when something *stops* happening, not when something fails

## Design

Hourly cron, three independent checks, each can alarm independently:

1. **Heartbeat liveness** — fetches `state/vitals.json` via Contents API (avoids stale checkout), alarms if `last_heartbeat_at` > 90 min old (3× the 30-min cron, tolerates brief misses).
2. **Examine health** — `gh run list --workflow=review.yml --limit 10`. Alarms on >30% failure rate OR any fork-PR failure in last 24h.
3. **Open-PR review staleness** — `gh pr list --state open`. Alarms for any PR >24h old with no review from `flux-dreaming-repo[bot]`.

Each alarm:
- Pings Telegram (existing `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` secrets).
- Opens-or-updates a single issue labeled `watchdog` (search by label first, edit body in place — never spams).

## Safety

- `schedule` + `workflow_dispatch` only — no `pull_request_target`, no fork exposure.
- Top-level `permissions:` block: `contents: read`, `issues: write`, `actions: read` (least privilege).
- All `${{ github.* }}` values pass through `env:` to shell, never templated into `run:` blocks (lesson from PR #23).
- Telegram message body sent via `--data-urlencode "text@<file>"` — no shell interpolation.
- Schedule `7 * * * *` decorrelates from heartbeat's `*/30 * * * *`.
- Zero third-party action `uses:` — pure bash + `gh` + `jq` + `curl`. Nothing to SHA-pin.
- `zizmor --min-severity high` clean against both current and strict (no-relaxation) configs.

## Test plan

- [ ] zizmor lint passes in CI
- [ ] Manual `workflow_dispatch` run produces no alarms in green state
- [ ] Verify Telegram message format on first real alarm (or by temporarily lowering thresholds)
- [ ] Verify issue update (not duplicate) on second consecutive alarming run

🤖 Generated with [Claude Code](https://claude.com/claude-code)