### PR TITLE
fix(heartbeat): autostash on rebase so dirty pulse files don't block push

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           git config user.name "flux-dreaming-repo[bot]"
           git config user.email "273547980+flux-dreaming-repo[bot]@users.noreply.github.com"
-          git pull --rebase origin main || true
+          git pull --rebase --autostash origin main || true
           git add state/ dreams/ memories/ README.md
           if ! git diff --cached --quiet; then
             COMMIT_MSG=$(cat state/.commit_message 2>/dev/null || echo "pulse")


### PR DESCRIPTION
## Summary
- One-flag fix: add \`--autostash\` to the \`git pull --rebase\` in heartbeat.yml's commit step.
- Pulse always modifies tracked files (\`vitals.json\`, \`last_dream.json\`, …) before this step. When remote main has moved, the rebase refuses on a dirty tree, \`|| true\` swallows it, and \`git push\` then fails because local main is behind.
- Surfaced today after #35 cleared the App-token wall — heartbeat reached this step for the first time in a while and immediately hit the latent ordering bug.

## Test plan
- [x] Diff is one flag — no behavior change when working tree is clean.
- [ ] Watch next heartbeat reach the commit step and push successfully.
- [ ] Confirm Telegram heartbeat-failed alerts stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)