### PR TITLE
chore(deps): group Dependabot minor+patch action bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     schedule:
       interval: weekly
     groups:
-      github-actions-minor:
+      github-actions-minor-patch:
         update-types:
           - minor
           - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,23 @@
 # silently; with it, Dependabot opens a weekly PR per action that bumps
 # the SHA AND updates the trailing `# vN` comment, so review.yml's
 # auto-review path can vouch for the bump.
+#
+# Grouping policy:
+#   - Minor + patch bumps batch into a single weekly PR per ecosystem.
+#     These are almost always safe (security patches, dep refreshes,
+#     no interface changes) and reviewing them one-by-one is just noise.
+#   - Major bumps stay separate. A v4 → v5 jump can change the runtime
+#     (Node 16 → 20 → 24), drop inputs, or alter default behaviour, so
+#     each one deserves its own PR — its own examine-by-Flux read of the
+#     diff and its own release-notes check.
 version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions-minor:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

- Add a `groups:` block to `.github/dependabot.yml` so weekly minor + patch action bumps batch into one PR per ecosystem.
- Major bumps stay individual — they can change the runtime (Node 16 → 20 → 24), remove inputs, or shift default behaviour, and each one deserves its own examine-by-Flux read.

## Context

Companion to PR #28 (which configured Dependabot in the first place). After #28, every weekly bump opened its own PR (#29–#33). Even when each bump is fine in isolation, five separate PRs per week is review-attention noise that obscures the one bump that actually matters. Grouping shrinks the steady-state load to ~1 PR/week + the rare major.

## Test plan

- [ ] Zizmor lint passes (no workflow files touched)
- [ ] Examine reads the diff and either ACCEPTs or asks for changes
- [ ] Next Monday's Dependabot run produces ≤ 1 grouped PR per ecosystem (if any minor/patch bumps exist)

Drafted so cage-match can run before Flux auto-merges.