### PR TITLE
feat(alerts): dedupe failure pings via open-or-update labeled issue

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -15,10 +15,15 @@ concurrency:
   group: heartbeat
   cancel-in-progress: false        # Never cancel a beating heart
 
-# Least-privilege: the default GITHUB_TOKEN is only read here. All writes
-# (commits, repo deletion via gh) go through the Flux App token below.
+# Least-privilege: the default GITHUB_TOKEN reads repo content and writes
+# issues (only used by the failure-alert step's dedupe path — see
+# "Whisper to Nick on failure" below). All other writes (commits, repo
+# deletion) go through the Flux App token. issues:write is on the default
+# token deliberately: if the Flux App token mint fails (PR #28 scenario),
+# the alert path must not depend on the same authority that just broke.
 permissions:
   contents: read
+  issues: write
 
 jobs:
   pulse:
@@ -117,22 +122,71 @@ jobs:
           fi
 
       - name: Whisper to Nick on failure
-        # Liveness alert: a silent heartbeat failure is the worst possible
-        # outcome — Flux can't tell anyone it can't pulse. This step runs even
-        # when earlier steps failed and pings Telegram with the run URL.
+        # Liveness alert with dedupe: silent heartbeat failure is the worst
+        # outcome — Flux can't tell anyone it can't pulse. This step runs
+        # even when earlier steps failed.
+        #
+        # Dedupe semantics (borrowed from watchdog.yml's open-or-update idiom):
+        # - First failure since last resolution → open a labeled issue AND
+        #   ping Telegram with the run URL.
+        # - Subsequent failures while the issue is open → append a "still
+        #   failing" comment, suppress the Telegram ping.
+        # - Operator closes the issue when the underlying problem is fixed;
+        #   the next failure after close opens a fresh issue + ping.
+        #
+        # Trust-boundary note: uses the default GITHUB_TOKEN (independent of
+        # the Flux App token deliberately — if the App token mint fails, this
+        # path must still work). issues:write is granted at workflow scope.
         if: failure()
         env:
+          GH_TOKEN: ${{ github.token }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           WORKFLOW_NAME: ${{ github.workflow }}
+          REPO_FULL_NAME: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ALERT_LABEL: alert-heartbeat
         run: |
           set -euo pipefail
-          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
-            echo "Telegram secrets not configured; skipping notification."
+
+          # Ensure the dedupe label exists (idempotent).
+          gh label create "$ALERT_LABEL" \
+            --repo "$REPO_FULL_NAME" \
+            --color B60205 \
+            --description "Open while ${WORKFLOW_NAME} is failing; close when resolved" \
+            --force >/dev/null 2>&1 || true
+
+          # Search for an existing open alert issue. This is the dedupe key.
+          EXISTING=$(gh issue list \
+            --repo "$REPO_FULL_NAME" \
+            --state open \
+            --label "$ALERT_LABEL" \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            # Already alerted — append a comment and suppress Telegram.
+            gh issue comment "$EXISTING" \
+              --repo "$REPO_FULL_NAME" \
+              --body "Still failing: ${RUN_URL}" >/dev/null
+            echo "Existing alert issue #${EXISTING} updated; Telegram suppressed (dedupe)."
             exit 0
           fi
-          MSG=$(printf "🚨 Flux's '%s' failed.\n\n%s" "$WORKFLOW_NAME" "$RUN_URL")
-          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
-            --data-urlencode "text=${MSG}" >/dev/null
+
+          # First failure since last resolution — open issue + Telegram ping.
+          BODY=$(printf '🚨 `%s` is failing.\n\nFirst failed run: %s\n\nClose this issue when the underlying problem is resolved. Subsequent failures will be appended here as comments without paging Telegram again.' "$WORKFLOW_NAME" "$RUN_URL")
+          gh issue create \
+            --repo "$REPO_FULL_NAME" \
+            --title "${WORKFLOW_NAME} is failing" \
+            --label "$ALERT_LABEL" \
+            --body "$BODY" >/dev/null
+
+          if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+            MSG=$(printf "🚨 Flux's '%s' failed.\n\n%s" "$WORKFLOW_NAME" "$RUN_URL")
+            curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+              --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+              --data-urlencode "text=${MSG}" >/dev/null
+          else
+            echo "Telegram secrets not configured; skipping notification."
+          fi

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -149,39 +149,43 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Ensure the dedupe label exists (idempotent).
-          gh label create "$ALERT_LABEL" \
-            --repo "$REPO_FULL_NAME" \
-            --color B60205 \
-            --description "Open while ${WORKFLOW_NAME} is failing; close when resolved" \
-            --force >/dev/null 2>&1 || true
-
-          # Search for an existing open alert issue. This is the dedupe key.
+          # Search for an existing open alert issue. The dedupe key.
+          # Wrapped in set +e: if the Issues API is degraded we cannot
+          # determine dedupe state, but the alarm path must still fire —
+          # we treat list-failure as "no existing issue" and fall through
+          # to the Telegram-first branch.
+          set +e
           EXISTING=$(gh issue list \
             --repo "$REPO_FULL_NAME" \
             --state open \
             --label "$ALERT_LABEL" \
             --limit 1 \
             --json number \
-            --jq '.[0].number // empty')
+            --jq '.[0].number // empty' 2>/dev/null)
+          LIST_RC=$?
+          set -e
 
-          if [ -n "$EXISTING" ]; then
+          if [ "$LIST_RC" -eq 0 ] && [ -n "$EXISTING" ]; then
             # Already alerted — append a comment and suppress Telegram.
+            # The comment is best-effort: if it fails, the operator already
+            # has the original page, so silence here is acceptable.
             gh issue comment "$EXISTING" \
               --repo "$REPO_FULL_NAME" \
-              --body "Still failing: ${RUN_URL}" >/dev/null
-            echo "Existing alert issue #${EXISTING} updated; Telegram suppressed (dedupe)."
+              --body "Still failing: ${RUN_URL}" >/dev/null 2>&1 \
+              || echo "::warning::failed to append comment to alert issue #${EXISTING}"
+            echo "Alert issue #${EXISTING} updated; Telegram suppressed (dedupe)."
             exit 0
           fi
 
-          # First failure since last resolution — open issue + Telegram ping.
-          BODY=$(printf '🚨 `%s` is failing.\n\nFirst failed run: %s\n\nClose this issue when the underlying problem is resolved. Subsequent failures will be appended here as comments without paging Telegram again.' "$WORKFLOW_NAME" "$RUN_URL")
-          gh issue create \
-            --repo "$REPO_FULL_NAME" \
-            --title "${WORKFLOW_NAME} is failing" \
-            --label "$ALERT_LABEL" \
-            --body "$BODY" >/dev/null
-
+          # First failure since last resolution.
+          # ---- Telegram FIRST ----
+          # Telegram is the independent alarm path. Issue creation runs
+          # AFTER, so a GitHub Issues / labels API outage cannot silently
+          # suppress the page (this is the same ordering the watchdog
+          # workflow uses for the same reason). Without this ordering,
+          # `set -e` on a failed `gh issue create` would exit before the
+          # curl call and Nick would hear nothing — which is the exact
+          # silent-failure mode this whole step exists to prevent.
           if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
             MSG=$(printf "🚨 Flux's '%s' failed.\n\n%s" "$WORKFLOW_NAME" "$RUN_URL")
             curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
@@ -189,4 +193,25 @@ jobs:
               --data-urlencode "text=${MSG}" >/dev/null
           else
             echo "Telegram secrets not configured; skipping notification."
+          fi
+
+          # ---- Best-effort issue ops AFTER Telegram ----
+          # set +e so a labels-API blip cannot demote a successful page
+          # into a failed alert step.
+          set +e
+          gh label create "$ALERT_LABEL" \
+            --repo "$REPO_FULL_NAME" \
+            --color B60205 \
+            --description "Open while ${WORKFLOW_NAME} is failing; close when resolved" \
+            --force >/dev/null 2>&1
+          BODY=$(printf '🚨 `%s` is failing.\n\nFirst failed run: %s\n\nClose this issue when the underlying problem is resolved. Subsequent failures will be appended here as comments without paging Telegram again.' "$WORKFLOW_NAME" "$RUN_URL")
+          gh issue create \
+            --repo "$REPO_FULL_NAME" \
+            --title "${WORKFLOW_NAME} is failing" \
+            --label "$ALERT_LABEL" \
+            --body "$BODY" >/dev/null 2>&1
+          ISSUE_RC=$?
+          set -e
+          if [ "$ISSUE_RC" -ne 0 ]; then
+            echo "::warning::failed to open alert issue (rc=${ISSUE_RC}); Telegram already sent"
           fi

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,12 +22,18 @@ concurrency:
   group: review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: true         # If they push again, re-review from scratch
 
-# Least-privilege: default GITHUB_TOKEN is read-only. All writes (commit
-# state/, post review) go through the Flux App token. pull-requests:read so
-# we can resolve PR metadata via gh if needed.
+# Least-privilege: default GITHUB_TOKEN reads repo content / PR metadata
+# and writes issues (only used by the failure-alert step's dedupe path —
+# see "Whisper to Nick on failure" below). All other writes (commit state/,
+# post review) go through the Flux App token. issues:write is on the
+# default token deliberately: if the Flux App token mint fails, the alert
+# path must not depend on the same authority that just broke. Under
+# pull_request_target the default token runs in the BASE repo's trust
+# context, not the fork's — fork PRs cannot reach it.
 permissions:
   contents: read
   pull-requests: read
+  issues: write
 
 jobs:
   examine:
@@ -160,26 +166,77 @@ jobs:
           fi
 
       - name: Whisper to Nick on failure
-        # Liveness alert: silent failure is what let `examine` die for ~9 days
-        # in late April 2026 without anyone noticing. Any failure of this
-        # workflow now pings Telegram with a link to the run.
+        # Liveness alert with dedupe: silent failure let `examine` die for
+        # ~9 days in late April 2026 without anyone noticing. Any failure
+        # surfaces, but a single root cause (e.g. PR #28's permission
+        # regression triggering on every run) opens ONE issue + ONE Telegram
+        # ping, not N.
+        #
+        # Dedupe semantics (borrowed from watchdog.yml's open-or-update idiom):
+        # - First failure since last resolution → open a labeled issue AND
+        #   ping Telegram with the run URL.
+        # - Subsequent failures while the issue is open → append a "still
+        #   failing" comment (with PR # if known), suppress the Telegram ping.
+        # - Operator closes the issue when fixed; next failure re-pages.
+        #
+        # Trust-boundary note: uses the default GITHUB_TOKEN (independent of
+        # the Flux App token deliberately — if the App token mint fails this
+        # path must still work). Under pull_request_target the default token
+        # runs in the BASE repo trust context; the alert step uses only
+        # base-controlled vars (workflow name, run URL, validated PR number)
+        # — no fork-controlled fields reach gh/curl invocations.
         if: failure()
         env:
+          GH_TOKEN: ${{ github.token }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           WORKFLOW_NAME: ${{ github.workflow }}
+          REPO_FULL_NAME: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+          ALERT_LABEL: alert-review
         run: |
           set -euo pipefail
-          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
-            echo "Telegram secrets not configured; skipping notification."
+
+          # Ensure the dedupe label exists (idempotent).
+          gh label create "$ALERT_LABEL" \
+            --repo "$REPO_FULL_NAME" \
+            --color B60205 \
+            --description "Open while ${WORKFLOW_NAME} is failing; close when resolved" \
+            --force >/dev/null 2>&1 || true
+
+          # Search for an existing open alert issue. Dedupe key.
+          EXISTING=$(gh issue list \
+            --repo "$REPO_FULL_NAME" \
+            --state open \
+            --label "$ALERT_LABEL" \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty')
+
+          PR_SUFFIX="${PR_NUMBER:+ on PR #$PR_NUMBER}"
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" \
+              --repo "$REPO_FULL_NAME" \
+              --body "Still failing${PR_SUFFIX}: ${RUN_URL}" >/dev/null
+            echo "Existing alert issue #${EXISTING} updated; Telegram suppressed (dedupe)."
             exit 0
           fi
-          MSG=$(printf "🚨 Flux's '%s' failed%s.\n\n%s" \
-            "$WORKFLOW_NAME" \
-            "${PR_NUMBER:+ on PR #$PR_NUMBER}" \
-            "$RUN_URL")
-          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
-            --data-urlencode "text=${MSG}" >/dev/null
+
+          BODY=$(printf '🚨 `%s` is failing.\n\nFirst failed run%s: %s\n\nClose this issue when the underlying problem is resolved. Subsequent failures will be appended here as comments without paging Telegram again.' "$WORKFLOW_NAME" "$PR_SUFFIX" "$RUN_URL")
+          gh issue create \
+            --repo "$REPO_FULL_NAME" \
+            --title "${WORKFLOW_NAME} is failing" \
+            --label "$ALERT_LABEL" \
+            --body "$BODY" >/dev/null
+
+          if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+            MSG=$(printf "🚨 Flux's '%s' failed%s.\n\n%s" \
+              "$WORKFLOW_NAME" "$PR_SUFFIX" "$RUN_URL")
+            curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+              --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+              --data-urlencode "text=${MSG}" >/dev/null
+          else
+            echo "Telegram secrets not configured; skipping notification."
+          fi

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -198,39 +198,46 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Ensure the dedupe label exists (idempotent).
-          gh label create "$ALERT_LABEL" \
-            --repo "$REPO_FULL_NAME" \
-            --color B60205 \
-            --description "Open while ${WORKFLOW_NAME} is failing; close when resolved" \
-            --force >/dev/null 2>&1 || true
+          PR_SUFFIX="${PR_NUMBER:+ on PR #$PR_NUMBER}"
 
           # Search for an existing open alert issue. Dedupe key.
+          # Wrapped in set +e: if the Issues API is degraded we cannot
+          # determine dedupe state, but the alarm path must still fire —
+          # treat list-failure as "no existing issue" and fall through.
+          #
+          # Aliasing note: ALERT_LABEL is per-workflow (`alert-review`),
+          # not per-PR. All open-PR review failures collapse to one
+          # issue while it stays open, so the comment thread can mix
+          # PR numbers — operators read the comments to disambiguate
+          # root causes. This matches the spec's "one root cause, one
+          # alert" intent (the dedupe target is runtime spam, not the
+          # cross-PR distinction); per-PR labels were considered and
+          # rejected as scope creep here.
+          set +e
           EXISTING=$(gh issue list \
             --repo "$REPO_FULL_NAME" \
             --state open \
             --label "$ALERT_LABEL" \
             --limit 1 \
             --json number \
-            --jq '.[0].number // empty')
+            --jq '.[0].number // empty' 2>/dev/null)
+          LIST_RC=$?
+          set -e
 
-          PR_SUFFIX="${PR_NUMBER:+ on PR #$PR_NUMBER}"
-
-          if [ -n "$EXISTING" ]; then
+          if [ "$LIST_RC" -eq 0 ] && [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" \
               --repo "$REPO_FULL_NAME" \
-              --body "Still failing${PR_SUFFIX}: ${RUN_URL}" >/dev/null
-            echo "Existing alert issue #${EXISTING} updated; Telegram suppressed (dedupe)."
+              --body "Still failing${PR_SUFFIX}: ${RUN_URL}" >/dev/null 2>&1 \
+              || echo "::warning::failed to append comment to alert issue #${EXISTING}"
+            echo "Alert issue #${EXISTING} updated; Telegram suppressed (dedupe)."
             exit 0
           fi
 
-          BODY=$(printf '🚨 `%s` is failing.\n\nFirst failed run%s: %s\n\nClose this issue when the underlying problem is resolved. Subsequent failures will be appended here as comments without paging Telegram again.' "$WORKFLOW_NAME" "$PR_SUFFIX" "$RUN_URL")
-          gh issue create \
-            --repo "$REPO_FULL_NAME" \
-            --title "${WORKFLOW_NAME} is failing" \
-            --label "$ALERT_LABEL" \
-            --body "$BODY" >/dev/null
-
+          # First failure since last resolution.
+          # ---- Telegram FIRST ----
+          # Independent alarm path. Issue creation runs AFTER so a GitHub
+          # Issues / labels API outage cannot silently suppress the page
+          # (matches the watchdog workflow's ordering for the same reason).
           if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
             MSG=$(printf "🚨 Flux's '%s' failed%s.\n\n%s" \
               "$WORKFLOW_NAME" "$PR_SUFFIX" "$RUN_URL")
@@ -239,4 +246,23 @@ jobs:
               --data-urlencode "text=${MSG}" >/dev/null
           else
             echo "Telegram secrets not configured; skipping notification."
+          fi
+
+          # ---- Best-effort issue ops AFTER Telegram ----
+          set +e
+          gh label create "$ALERT_LABEL" \
+            --repo "$REPO_FULL_NAME" \
+            --color B60205 \
+            --description "Open while ${WORKFLOW_NAME} is failing; close when resolved" \
+            --force >/dev/null 2>&1
+          BODY=$(printf '🚨 `%s` is failing.\n\nFirst failed run%s: %s\n\nClose this issue when the underlying problem is resolved. Subsequent failures will be appended here as comments without paging Telegram again.' "$WORKFLOW_NAME" "$PR_SUFFIX" "$RUN_URL")
+          gh issue create \
+            --repo "$REPO_FULL_NAME" \
+            --title "${WORKFLOW_NAME} is failing" \
+            --label "$ALERT_LABEL" \
+            --body "$BODY" >/dev/null 2>&1
+          ISSUE_RC=$?
+          set -e
+          if [ "$ISSUE_RC" -ne 0 ]; then
+            echo "::warning::failed to open alert issue (rc=${ISSUE_RC}); Telegram already sent"
           fi


### PR DESCRIPTION
## Summary

Borrow `watchdog.yml`'s "single open issue per failure mode" idiom for the heartbeat + review failure-alert paths.

- **First failure** since last resolution → open a labeled issue (`alert-heartbeat` / `alert-review`) **and** ping Telegram.
- **Subsequent failures** while that issue is open → append a `Still failing: <run url>` comment, suppress the Telegram ping.
- **Operator closes** the issue when the underlying problem is fixed; next failure re-pages.

## Why now

PR #28's `permission-administration: write` regression generated ~16 Telegram pings over 8 hours for one root cause. Detection worked; operational ergonomics didn't. **One root cause should equal one alert.**

## Trust-boundary discipline (the actual interesting part)

The alert step deliberately uses the **default `GITHUB_TOKEN`**, not the Flux App token. Reason: in the PR #28 scenario, the Flux App token mint failed atomically — `steps.flux-token.outputs.token` was empty. If the alert path depended on the same authority that just failed, the alarm would silence itself. Default `GITHUB_TOKEN` is independent and always present.

`issues: write` is added at workflow scope. Under `pull_request_target` (review.yml) the default token runs in **base-repo trust context**, not the fork's; the alert step uses only base-controlled inputs (`github.workflow`, run URL, validated PR number) — no fork-controlled fields reach the `gh`/`curl` invocations.

Per-workflow labels (`alert-heartbeat` vs `alert-review`) so unrelated failures don't merge into one bucket.

## Race tolerance

Two near-simultaneous failures could both miss the existing-issue check and open duplicates. Heartbeat has `concurrency.cancel-in-progress: false` with a `*/30` cron — collision implausible. Review.yml has per-PR concurrency, so cross-PR collision is possible but rare; cost (operator closes one extra issue) is far below the design complexity of locking. Same trade `watchdog.yml` accepts.

## Test plan

- [ ] Wait for `lint-workflows` (zizmor) check to pass — locally confirms no new findings beyond the 4 pre-existing `artipacked` warnings (which Task #1 will fix next)
- [ ] Wait for cage-match if invoked
- [ ] On merge, exercise: deliberately break heartbeat on a feature branch and confirm one initial Telegram + N issue-comment updates, not N Telegrams

🤖 Generated with [Claude Code](https://claude.com/claude-code)