### PR TITLE
fix(heartbeat): refuse to commit when autostash pop leaks conflict markers

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -115,13 +115,19 @@ jobs:
           # and the next 30-min pulse starts from a clean checkout.
           git pull --rebase --autostash origin main || true
 
-          if grep -lrE '^(<<<<<<< |=======$|>>>>>>> )' \
-              state/ dreams/ memories/ README.md 2>/dev/null \
-              | grep -q .; then
+          # Capture into a variable rather than `grep | grep -q .`. The
+          # pipeline form is unsafe under `set -euo pipefail`: `grep -q`
+          # exits 0 on the first match and closes the pipe, the upstream
+          # recursive grep gets SIGPIPE (rc=141), and `pipefail`
+          # propagates that as the pipeline status — so the `if` reads
+          # false even when markers exist. Capturing avoids the pipe
+          # entirely. (Carnot's HIGH finding on PR #43 cage-match.)
+          MARKER_FILES=$(grep -lrE '^(<<<<<<< |=======$|>>>>>>> )' \
+            state/ dreams/ memories/ README.md 2>/dev/null || true)
+          if [ -n "$MARKER_FILES" ]; then
             echo "::error::autostash pop left conflict markers; refusing to commit"
             echo "Files with markers:"
-            grep -lrE '^(<<<<<<< |=======$|>>>>>>> )' \
-              state/ dreams/ memories/ README.md 2>/dev/null
+            printf '%s\n' "$MARKER_FILES"
             exit 1
           fi
 

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -92,9 +92,39 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.flux-token.outputs.token }}
         run: |
+          set -euo pipefail
           git config user.name "flux-dreaming-repo[bot]"
           git config user.email "273547980+flux-dreaming-repo[bot]@users.noreply.github.com"
+
+          # `--autostash` silently leaves literal conflict markers
+          # (`<<<<<<<` / `=======` / `>>>>>>>`) in the working tree if
+          # the stash pop conflicts with rebased upstream changes. The
+          # previous `|| true` swallowed that failure; the next `git add`
+          # then unconditionally staged the broken files; commit + push
+          # landed conflict markers on main.
+          #
+          # On 2026-05-04 this lined up such that state/vitals.json on
+          # main carried conflict markers for ~14h, breaking watchdog's
+          # jq parse of the heartbeat-liveness check and triggering 33
+          # Telegram pings overnight.
+          #
+          # Defense: scan the tree for conflict markers AFTER the rebase
+          # and refuse to commit if any are present. Failing the heartbeat
+          # loudly is strictly better than polluting main — the failure-
+          # alert step fires (with dedupe via PR #40), Nick gets ONE page,
+          # and the next 30-min pulse starts from a clean checkout.
           git pull --rebase --autostash origin main || true
+
+          if grep -lrE '^(<<<<<<< |=======$|>>>>>>> )' \
+              state/ dreams/ memories/ README.md 2>/dev/null \
+              | grep -q .; then
+            echo "::error::autostash pop left conflict markers; refusing to commit"
+            echo "Files with markers:"
+            grep -lrE '^(<<<<<<< |=======$|>>>>>>> )' \
+              state/ dreams/ memories/ README.md 2>/dev/null
+            exit 1
+          fi
+
           git add state/ dreams/ memories/ README.md
           if ! git diff --cached --quiet; then
             COMMIT_MSG=$(cat state/.commit_message 2>/dev/null || echo "pulse")


### PR DESCRIPTION
## What

Add a conflict-marker scan after `git pull --rebase --autostash || true` in heartbeat.yml's "Commit to long-term memory" step. If markers are present in `state/`, `dreams/`, `memories/`, or `README.md`, log the file list and exit 1.

## Why

This is the **root cause** of the 2026-05-04 watchdog flood that woke Nick to 33 Telegram pings.

Walk it through:

1. `git pull --rebase --autostash` rebases upstream and pops the stash.
2. Pop conflicts (both upstream and the heartbeat's local writes touched the same lines in vitals.json / README.md / dreams/).
3. autostash-pop leaves literal `<<<<<<<` / `=======` / `>>>>>>>` markers in the working tree.
4. `|| true` swallows the failure rc.
5. `git add state/ dreams/ memories/ README.md` unconditionally stages everything, including the marker-marked files.
6. `git commit && git push` lands conflict markers on `main`.
7. Next watchdog run base64-decodes vitals.json from main, pipes to `jq`, jq dies on the markers, heartbeat-liveness check exits non-zero, watchdog's aggregate-step safety logic alarms, Telegram fires.
8. Watchdog had no Telegram dedupe (PR #42 fixes that separately) → 33 pings over 8h.

## The fix

Minimal guard: detect markers; bail loud. The trade is "occasional missed pulse on rebase conflict" vs. "polluted main + cascading alert flood." Easy call.

```bash
if grep -lrE '^(<<<<<<< |=======$|>>>>>>> )' state/ dreams/ memories/ README.md 2>/dev/null | grep -q .; then
  echo "::error::autostash pop left conflict markers; refusing to commit"
  ...
  exit 1
fi
```

Failure surfaces through the existing failure-alert path. With PR #40 merged, that's deduped to one Telegram per outage instead of N.

## Out of scope (intentional)

A deeper redesign — drop `--autostash` entirely; do the python work *after* pull, not before — would be cleaner but reorders the heartbeat lifecycle and needs separate validation. This minimal guard prevents the failure mode that actually bit us. If autostash conflicts turn out to be frequent (this is a sample size of 1), a follow-up PR can do the lifecycle redesign.

## Test plan

- [ ] Cage-match
- [ ] Wait for CI green (zizmor + examine)
- [ ] Mark ready, await Nick's CODEOWNERS approval
- [ ] **Post-merge verification (per `feedback_verify_on_production_ref.md`):**
  - [ ] Read heartbeat.yml from `main` ref via API; confirm guard is present
  - [ ] Watch one heartbeat cron cycle and confirm normal pulse still works
  - [ ] (Cannot test the guard's positive path without forcing a conflict; ack and skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)