### PR TITLE
fix(heartbeat): fail-soft on corrupted vitals in 'Die if it's time' step

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -149,8 +149,30 @@ jobs:
           GH_TOKEN: ${{ steps.flux-token.outputs.token }}
           REPO_FULL_NAME: ${{ github.repository }}
         run: |
+          # Fail-soft parse: if vitals.json is corrupted (as happened
+          # 2026-05-04 → 2026-05-12 with leaked git conflict markers),
+          # crashing here makes heartbeat appear dead and pages Telegram
+          # — even though the answer to "should we die?" is unambiguously
+          # "no, we can't even tell". Treat a parse failure as
+          # cause_of_death="" (i.e. don't delete). `bash -e` already
+          # protected us from a spurious `gh repo delete` (the prior crash
+          # short-circuited before the comparison), but it cost us a
+          # workflow-failure alarm. This mirrors the pattern PR #47 applied
+          # to src/review.py — see docs/recovery.md.
           if [ -f state/vitals.json ]; then
-            CAUSE=$(python3 -c "import json; v=json.load(open('state/vitals.json')); print(v.get('cause_of_death',''))")
+            CAUSE=$(python3 <<'PY'
+          import json
+          try:
+              with open("state/vitals.json") as f:
+                  print(json.load(f).get("cause_of_death", ""))
+          except Exception as e:
+              # Print to stderr so it appears in the run log, but emit
+              # an empty stdout so CAUSE="" and the silence check fails.
+              import sys
+              print(f"::warning::vitals.json failed to parse ({e}); treating cause_of_death as empty", file=sys.stderr)
+              print("")
+          PY
+          )
             if [ "$CAUSE" = "silence" ]; then
               echo "Flux has died. Deleting repository."
               gh repo delete "$REPO_FULL_NAME" --yes


### PR DESCRIPTION
## Summary

Sibling of #47, applied to the `Die if it's time` step in `heartbeat.yml`. That step was the only remaining unguarded `json.load` in workflow shell:

```
$ grep -nE 'json\.load' .github/workflows/*.yml
.github/workflows/heartbeat.yml:153:            CAUSE=$(python3 -c "import json; v=json.load(open('state/vitals.json'))...")
```

It crashed at 2026-05-12T10:00:23Z during the conflict-marker deadlock (issue #46, now closed) and paged Telegram. `bash -e` already prevented a spurious `gh repo delete` (the parse crash short-circuited before the silence check), so worst-case was a false alarm — but the alarm itself is real noise.

## Change

Replace `python3 -c "import json; v=json.load(...); print(v.get('cause_of_death',''))"` with a `<<'PY'` heredoc that wraps the read in try/except:

- success → stdout = cause_of_death (existing behavior)
- failure → stderr = `::warning::...`, stdout = `""` → CAUSE="" → silence check fails → no delete

The semantic shift is intentional: **treat uncertainty as 'alive'**. Killing on uncertainty is the wrong direction here — the question \"is Flux dead?\" has a conservative default.

## Test plan

Local reproduction with three `vitals.json` shapes:

| Input | Old behavior | New behavior |
|-------|--------------|--------------|
| Conflict-marker corruption | crash (set -e fails step, no delete by accident) | CAUSE='', no delete, warning in log |
| `{\"cause_of_death\":\"silence\"}` | CAUSE='silence', delete | unchanged |
| `{\"cause_of_death\":\"\"}` | CAUSE='', no delete | unchanged |

- [x] Local stress test against all three shapes
- [x] YAML re-parses; `python3 yaml.safe_load` shows clean heredoc indentation
- [ ] heartbeat workflow runs green on this PR (will verify after merge — `heartbeat.yml` doesn't run on PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)