### PR TITLE
feat(heartbeat): auto-resolve alert-heartbeat issue on recovery

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -273,3 +273,68 @@ jobs:
           if [ "$ISSUE_RC" -ne 0 ]; then
             echo "::warning::failed to open alert issue (rc=${ISSUE_RC}); Telegram already sent"
           fi
+
+      - name: Auto-resolve alert on recovery
+        # Close any open alert-heartbeat issue when this run succeeds.
+        # Removes the manual-triage tax: three near-identical
+        # "heartbeat is failing" issues were opened+closed by hand in
+        # 24h (issues #46, #48, #50), each from a single transient
+        # autostash race that the next scheduled run cleared by itself.
+        # The dedupe in "Whisper to Nick on failure" already suppresses
+        # repeat Telegram pings; this step closes the loop on the
+        # GitHub-issue side.
+        #
+        # Cascade analysis: closing an issue triggers `issues: closed`
+        # and adding a comment triggers `issue_comment: created` — both
+        # are heartbeat triggers, so each close kicks 2 more runs.
+        # The runs serialize (concurrency: heartbeat, cancel-in-progress: false)
+        # and the open-issue check below is the only event-emitting
+        # action — when no alert is open, this step is a single read
+        # API call and exits silently. Expected amplification per
+        # autostash-race-rate r: ~2r new alerts per close, geometric
+        # tail ≈ original × 1/(1-2r) — negligible at observed r.
+        #
+        # Persistent failures don't get masked: if the next run also
+        # fails, this step's `if: success()` doesn't fire, the alert
+        # stays open, and the failure-step's dedupe still suppresses
+        # the Telegram re-page.
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_FULL_NAME: ${{ github.repository }}
+          ALERT_LABEL: alert-heartbeat
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        run: |
+          set -euo pipefail
+
+          # set +e around the list so an Issues-API blip doesn't fail
+          # the step. The alert path can be re-cleared on the next run.
+          set +e
+          OPEN=$(gh issue list \
+            --repo "$REPO_FULL_NAME" \
+            --state open \
+            --label "$ALERT_LABEL" \
+            --limit 10 \
+            --json number \
+            --jq '.[].number')
+          LIST_RC=$?
+          set -e
+
+          if [ "$LIST_RC" -ne 0 ]; then
+            echo "::warning::failed to list open alert issues (rc=${LIST_RC}); leaving for next run"
+            exit 0
+          fi
+          if [ -z "$OPEN" ]; then
+            # Common path: no alert open. Exit silently — no event
+            # emissions, no cascade.
+            exit 0
+          fi
+
+          for N in $OPEN; do
+            echo "Auto-closing alert issue #${N} (heartbeat recovered at ${RUN_URL})"
+            gh issue close "$N" \
+              --repo "$REPO_FULL_NAME" \
+              --comment "✅ Recovered: \`${WORKFLOW_NAME}\` succeeded at ${RUN_URL}. Auto-closing." \
+              || echo "::warning::failed to auto-close #${N}"
+          done


### PR DESCRIPTION
## Summary

Eliminate the manual-triage tax on transient heartbeat failures. Three near-identical *"heartbeat is failing"* issues (#46 #48 #50) were opened and closed by hand in 24h, each from a single autostash race that the next scheduled run cleared on its own. The Telegram-side dedupe already suppresses repeat pings; this PR closes the loop on the GitHub-issue side.

The autostash defense (PR #43) and the vitals.json fail-soft (PR #49) are working as designed — they convert silent corruption into loud, fast-failing alerts. But each fire produces an alert issue that has to be manually closed even though no human intervention was needed. Auto-resolve on the next successful run is the missing piece.

## What changes

New step `Auto-resolve alert on recovery` (`if: success()`) at the end of the pulse job:

1. List open `alert-heartbeat` issues — one read API call, no event emissions.
2. If none open → exit silently (common path, no cascade).
3. Otherwise → close each with a `✅ Recovered` comment linking the successful run.

## Cascade analysis

Closing an issue → `issues: closed`. Adding a comment → `issue_comment: created`. Both are heartbeat triggers, so each close kicks 2 more runs. They serialize via the existing `heartbeat` concurrency group (`cancel-in-progress: false`). The list-check above is the only event-emitting action, and only runs when an alert is open, so the no-alert common case has zero amplification.

Expected new-alerts-per-close ≈ 2 × (autostash race rate). Observed rate r ≈ 0.03 per heartbeat run (3 alerts in 24h × 48 runs/day). Amplification factor ≈ 1/(1−2r) ≈ 1.06 — negligible.

Persistent failures don't get masked: `if: success()` means a still-failing run leaves the alert open. The next genuinely successful run is what auto-closes.

## Verification

- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Step renders with expected `if:` guards: 3 terminal steps in order `always() / failure() / success()`
- [x] zizmor at current `--min-severity high` clean. (At `medium` there's one `artipacked` finding at line 52 — that's the one PR #39 fixes; not introduced by this change.)
- [x] Manual smoke: the exact `gh issue list ... --json number --jq '.[].number'` query works against this repo
- [ ] First post-merge run will auto-close any alert issues open at that moment (currently 0 — I closed #50 a few minutes ago — so the first observation will be the *no-alert silent path*, not the close path)
- [ ] The close path will be exercised on the next autostash-race incident (observed rate ~0.03/run → expect within the next ~30 runs / ~15h)

## Stacking note

Independent of PRs #38 (watchdog) and #39 (zizmor artipacked) but in the same CODEOWNERS-gated `.github/` area. No file conflicts; all three can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)