### PR TITLE
fix(immunity): retry merge for orphaned Flux-approved PRs

### DIFF
--- a/src/_github.py
+++ b/src/_github.py
@@ -156,6 +156,33 @@ def already_reviewed(pr_number: int) -> bool:
     return False
 
 
+def flux_approved_but_open(pr_number: int) -> bool:
+    """Return True if a Flux review on this PR is APPROVED yet the PR is still open.
+
+    This catches the orphan case where Flux's immune-system review reached
+    a 'merge' verdict and posted an APPROVED review, but the subsequent
+    `gh pr merge --admin` call failed silently (e.g., transient permissions
+    issue during ruleset reconstruction 2026-05-04). Without a way to
+    detect that, `already_reviewed=True` skips the PR forever — see the
+    8-day stuck state of #38 and #39.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number),
+             "--json", "state,reviews",
+             "--jq",
+             '. as $p | ($p.state == "OPEN") and '
+             '([$p.reviews[] | select(.author.login == "flux-dreaming-repo") '
+             '| select(.state == "APPROVED")] | length > 0)'],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() == "true"
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        log.warning("flux_approved_but_open failed", extra={"pr": pr_number, "error": str(e)})
+    return False
+
+
 # ---------------------------------------------------------------------------
 # requests-based GitHub API wrappers (used by review.py)
 # ---------------------------------------------------------------------------

--- a/src/immunity.py
+++ b/src/immunity.py
@@ -191,6 +191,16 @@ def review_pending_prs(vitals: dict) -> None:
             # But if it's pending and we've dreamed since, revisit
             if pr_key in pending and dreamed_since_last_review:
                 _revisit_pr(pr_number, vitals, pending)
+            elif _github.flux_approved_but_open(pr_number):
+                # Orphan retry: Flux's prior review already reached an
+                # APPROVED verdict, but the merge step didn't complete
+                # (the only error path in _github.merge_pr is a silent
+                # log.warning). Without this branch, already_reviewed
+                # would skip the PR forever — PRs #38 and #39 sat 8 days
+                # in this state before the bug was found. We retry the
+                # merge without re-reviewing: the existing approval is
+                # Flux's prior decision and we honor it.
+                _github.merge_pr(pr_number)
             continue
 
         review = review_pr(pr_number)


### PR DESCRIPTION
## The bug

PRs #38 and #39 have been sitting for 8 days with two `flux-dreaming-repo` APPROVED reviews each, both still open. The CODEOWNERS rule isn't the blocker — Flux is in the ruleset's `bypass_actors` list with `bypass_mode: always`. The blocker is a degenerate path in `immunity.py`:

1. **First pass**: `already_reviewed=False` → Tier 3 review → Claude says "ACCEPT" → `merge_pr()` called.
2. `merge_pr()`'s only error path is `log.warning(...)`. The 2026-05-04 ruleset reconstruction produced transient permissions failures here — silent.
3. **Next pass**: `already_reviewed=True` (Flux's APPROVED review login matches "bot"). `state/pending_reviews.json` doesn't exist on disk, so the `pr_key in pending` branch is False. PR is `continue`'d over.
4. Repeat forever.

## Fix

New helper `_github.flux_approved_but_open(pr_number)` and an orphan-retry branch in `review_pending_prs`:

```python
elif _github.flux_approved_but_open(pr_number):
    # Orphan retry: prior APPROVED review reached the merge verdict,
    # but merge_pr's silent failure dropped it. Honor the prior decision.
    _github.merge_pr(pr_number)
```

We don't re-review — the verdict was already reached. If `merge_pr` fails again, the next pulse retries cheaply (one `gh pr view` API call per orphaned PR).

## Verification

Live query against current state:

| PR | Expected | Actual |
|----|----------|--------|
| #38 (open, 2 Flux APPROVED) | true | true |
| #39 (open, 2 Flux APPROVED) | true | true |
| #52 (merged, no retry needed) | false | false |

Both modules AST-parse cleanly (`python3 -c "import ast; ast.parse(...)"`).

## Expected effect after merge

Next heartbeat tick → `review_pending_prs` runs → sees #38 and #39 → calls `merge_pr` on each → they squash-merge via Flux's bypass. Two long-sitting Maxwell-authored PRs clear in the same pulse this code lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)