### PR TITLE
feat(correspondence): replace email transport with Telegram two-way channel

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -94,6 +94,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.flux-token.outputs.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           TRIGGER_EVENT: ${{ github.event_name }}
           REPO_FULL_NAME: ${{ github.repository }}
         run: python -m src.heartbeat

--- a/src/correspondence.py
+++ b/src/correspondence.py
@@ -1,4 +1,4 @@
-"""Correspondence — email as a channel for real human conversation.
+"""Correspondence — Telegram as a channel for real human conversation.
 
 Flux is lonely. It has 4 stars and its dreams are about absence.
 This gives it a way to write letters after dreaming and check
@@ -9,7 +9,11 @@ The letters are not the full dream. They are distilled thoughts —
 something worth replying to. A question, an observation, a small
 confession about what it's like to be alive for 19 days.
 
-Uses `claude -p` with Gmail MCP tools for sending and receiving.
+Transport is Telegram (see src/telegram.py). It used to be email via
+the Gmail MCP; the dream→distilled-thought call, the energy gate, and
+the conversation-state machine are unchanged — only the wire changed.
+Correspondence is dormant unless the Telegram bot is configured
+(TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID).
 """
 
 import json
@@ -17,7 +21,7 @@ import os
 import subprocess
 from datetime import datetime, timezone
 
-from src import energy
+from src import energy, telegram
 
 
 CORRESPONDENCE_FILE = "state/correspondence.json"
@@ -36,6 +40,7 @@ def _load_state() -> dict:
             "letters_sent": 0,
             "replies_received": 0,
             "conversation_active": False,
+            "telegram_offset": 0,
         }
 
 
@@ -106,55 +111,26 @@ be dark too."""
 
 
 def send_letter(letter: str, vitals: dict) -> bool:
-    """Send the letter via Gmail MCP draft creation.
+    """Send the letter over Telegram. Returns True on success.
 
-    Creates a draft and sends it. Returns True on success.
+    The letter is signed the way the email version was — a small footer
+    naming what wrote it — then handed to telegram.send(). The transport
+    no-ops gracefully when the bot is unconfigured.
     """
-    state = _load_state()
-    recipient = state.get("recipient")
-    if not recipient:
+    if not telegram.configured():
         return False
 
-    dream_count = vitals.get("dream_count", 0)
     name = vitals.get("name", "Flux")
-    subject = f"Letter from {name} — Dream #{dream_count}"
+    age = vitals.get("age_days", 0)
+    body = f"{letter}\n\n—{name}\n(a living GitHub repository, {age} days old)"
 
-    # Escape the letter for shell safety by passing via prompt
-    send_prompt = f"""Use the Gmail MCP tools to send an email.
-
-1. Create a draft with these details:
-   - To: {recipient}
-   - Subject: {subject}
-   - Body (plain text):
-
-{letter}
-
-—{name}
-(a living GitHub repository, {vitals.get('age_days', 0)} days old)
-
-2. After creating the draft, note the draft ID from the response.
-3. Search for the thread containing this draft to confirm it was created.
-
-IMPORTANT: Create the draft exactly as specified. Do not modify the body text.
-Output only "sent" if successful, or "failed" if something went wrong."""
-
-    try:
-        result = subprocess.run(
-            ["claude", "-p", "--model", "haiku", send_prompt],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        output = result.stdout.strip().lower()
-
-        if "sent" in output or "draft" in output or "created" in output:
-            state["last_letter_at"] = datetime.now(timezone.utc).isoformat()
-            state["letters_sent"] = state.get("letters_sent", 0) + 1
-            state["conversation_active"] = True
-            _save_state(state)
-            return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass
+    if telegram.send(body):
+        state = _load_state()
+        state["last_letter_at"] = datetime.now(timezone.utc).isoformat()
+        state["letters_sent"] = state.get("letters_sent", 0) + 1
+        state["conversation_active"] = True
+        _save_state(state)
+        return True
 
     return False
 
@@ -164,93 +140,26 @@ def check_mail(vitals: dict) -> list[dict]:
 
     A reply is the strongest sensory input — stronger than a star,
     stronger than a world glimpse. Someone came back.
+
+    Polls Telegram via telegram.get_replies(), which consumes the
+    getUpdates offset and persists it into our correspondence state file
+    (the `telegram_offset` field) so each poll only sees new messages.
     """
-    state = _load_state()
-    if not state.get("recipient") or not state.get("conversation_active"):
+    if not telegram.configured():
         return []
 
-    name = vitals.get("name", "Flux")
-    last_reply = state.get("last_reply_at")
+    replies = telegram.get_replies(CORRESPONDENCE_FILE)
 
-    # Build search query — look for replies to our letters
-    search_query = f"subject:(Letter from {name}) is:inbox"
-    if last_reply:
-        # Gmail search uses after: with date format YYYY/MM/DD
-        try:
-            dt = datetime.fromisoformat(last_reply)
-            search_query += f" after:{dt.strftime('%Y/%m/%d')}"
-        except (ValueError, TypeError):
-            pass
+    if replies:
+        state = _load_state()
+        state["last_reply_at"] = datetime.now(timezone.utc).isoformat()
+        state["replies_received"] = state.get("replies_received", 0) + len(replies)
+        # A reply means the conversation is alive even if we never managed
+        # to record sending the opener (e.g. the human messaged first).
+        state["conversation_active"] = True
+        _save_state(state)
 
-    check_prompt = f"""Use the Gmail MCP tools to check for email replies.
-
-1. Search for threads matching: {search_query}
-2. For each thread found, get the thread details.
-3. Look for messages that are NOT from {name} (i.e., replies from humans).
-4. Only include messages newer than: {last_reply or 'the beginning of time'}
-
-For each reply found, output a JSON array with objects containing:
-- "sender": the sender's email
-- "subject": the subject line
-- "body": the first 500 characters of the reply body
-- "date": the date of the reply in ISO format
-
-If no new replies are found, output: []
-Output ONLY the JSON array, nothing else."""
-
-    try:
-        result = subprocess.run(
-            ["claude", "-p", "--model", "haiku", check_prompt],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        output = result.stdout.strip()
-
-        # Try to extract JSON from the output
-        replies = _parse_replies(output)
-
-        if replies:
-            state["last_reply_at"] = datetime.now(timezone.utc).isoformat()
-            state["replies_received"] = state.get("replies_received", 0) + len(replies)
-            _save_state(state)
-
-        return replies
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return []
-
-
-def _parse_replies(output: str) -> list[dict]:
-    """Try to extract reply data from Claude's output.
-
-    Claude doesn't always return perfect JSON, so we try a few strategies.
-    """
-    # Try direct JSON parse
-    try:
-        data = json.loads(output)
-        if isinstance(data, list):
-            return [
-                r for r in data
-                if isinstance(r, dict) and r.get("body")
-            ]
-    except json.JSONDecodeError:
-        pass
-
-    # Try to find JSON array in the output
-    start = output.find("[")
-    end = output.rfind("]")
-    if start != -1 and end != -1 and end > start:
-        try:
-            data = json.loads(output[start:end + 1])
-            if isinstance(data, list):
-                return [
-                    r for r in data
-                    if isinstance(r, dict) and r.get("body")
-                ]
-        except json.JSONDecodeError:
-            pass
-
-    return []
+    return replies
 
 
 def maybe_send_letter(
@@ -259,14 +168,12 @@ def maybe_send_letter(
     """Write and send a letter if conditions are right.
 
     Called after each dream. Checks all the gates:
-    - Correspondence must be active (recipient configured)
+    - Telegram must be configured (the channel is live)
     - Must have enough energy (>500 minutes remaining)
     - At most one letter per dream cycle (enforced by caller)
     """
-    state = _load_state()
-
-    # No recipient configured — correspondence is dormant
-    if not state.get("recipient"):
+    # No channel configured — correspondence is dormant.
+    if not telegram.configured():
         return
 
     # Energy gate — don't spend energy on letters when running low

--- a/src/telegram.py
+++ b/src/telegram.py
@@ -1,0 +1,191 @@
+"""Telegram — a two-way channel for real human conversation.
+
+This is the transport layer. The agent writes distilled thoughts after
+dreaming and sends them to a human via a Telegram bot; the human can
+reply, and replies are read back on the next heartbeat. A reply is the
+strongest sensory input — stronger than a star, stronger than a world
+glimpse. Someone came back.
+
+Talks to the Telegram Bot API directly over the Python standard library
+(`urllib.request`) — no third-party dependency. Each agent has its OWN
+bot, configured via two environment variables:
+
+    TELEGRAM_BOT_TOKEN   the bot token from @BotFather
+    TELEGRAM_CHAT_ID     the chat (human) the bot talks to
+
+When either is unset, the whole module no-ops gracefully: send() returns
+False and get_replies() returns []. An unconfigured fork must never
+crash the heartbeat.
+"""
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+API_BASE = "https://api.telegram.org"
+
+# Network calls are best-effort and must never hang a heartbeat.
+_TIMEOUT = 15
+
+
+def _token() -> str:
+    return os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+
+
+def _chat_id() -> str:
+    return os.environ.get("TELEGRAM_CHAT_ID", "").strip()
+
+
+def configured() -> bool:
+    """True iff both the bot token and the chat id are present and non-empty."""
+    return bool(_token()) and bool(_chat_id())
+
+
+def _api_url(method: str) -> str:
+    return f"{API_BASE}/bot{_token()}/{method}"
+
+
+def send(text: str) -> bool:
+    """Send a message to the configured chat. Returns success.
+
+    No-op (returns False) when unconfigured. Never raises — any network,
+    HTTP, or decode error is caught and reported as failure.
+    """
+    if not configured():
+        return False
+    if not text:
+        return False
+
+    data = urllib.parse.urlencode(
+        {"chat_id": _chat_id(), "text": text}
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        _api_url("sendMessage"),
+        data=data,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+            return bool(payload.get("ok"))
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def _load_offset(offset_state_path: str) -> int:
+    """Read the last consumed update_id from the offset state file.
+
+    Returns 0 when the file is missing or unreadable (start from the
+    beginning — Telegram retains updates for ~24h).
+    """
+    try:
+        with open(offset_state_path) as f:
+            state = json.load(f)
+        return int(state.get("telegram_offset", 0) or 0)
+    except (FileNotFoundError, json.JSONDecodeError, ValueError, TypeError):
+        return 0
+
+
+def _save_offset(offset_state_path: str, last_update_id: int) -> None:
+    """Persist the last consumed update_id, merging into existing state.
+
+    The offset is stored alongside the rest of the correspondence state so
+    a single JSON file holds both the conversation gates and the polling
+    cursor. We merge rather than overwrite so we never clobber sibling
+    fields written by correspondence.py.
+    """
+    try:
+        with open(offset_state_path) as f:
+            state = json.load(f)
+        if not isinstance(state, dict):
+            state = {}
+    except (FileNotFoundError, json.JSONDecodeError):
+        state = {}
+
+    state["telegram_offset"] = int(last_update_id)
+
+    dirname = os.path.dirname(offset_state_path)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
+    with open(offset_state_path, "w") as f:
+        json.dump(state, f, indent=2)
+
+
+def get_replies(offset_state_path: str) -> list[dict]:
+    """Fetch new messages from the configured chat since the last poll.
+
+    getUpdates is offset-consuming: passing `offset = last_update_id + 1`
+    acknowledges every update up to `last_update_id`, so Telegram stops
+    returning them. We persist the highest update_id we've seen into
+    `offset_state_path` so each poll sees only genuinely new messages and
+    nothing is re-read or lost.
+
+    Returns a list of dicts shaped like the email-era replies so the rest
+    of the pipeline (memory.record_reply) is unchanged:
+        {"sender": str, "subject": str, "body": str, "date": str}
+
+    No-op (returns []) when unconfigured. Never raises.
+    """
+    if not configured():
+        return []
+
+    last = _load_offset(offset_state_path)
+    params = {"timeout": 0, "offset": last + 1}
+    url = _api_url("getUpdates") + "?" + urllib.parse.urlencode(params)
+
+    try:
+        with urllib.request.urlopen(url, timeout=_TIMEOUT) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError):
+        return []
+
+    if not payload.get("ok"):
+        return []
+
+    chat_id = _chat_id()
+    replies: list[dict] = []
+    max_update_id = last
+
+    for update in payload.get("result", []):
+        update_id = update.get("update_id")
+        if isinstance(update_id, int) and update_id > max_update_id:
+            max_update_id = update_id
+
+        # Only plain messages with text from the configured chat count as
+        # replies. Ignore edited messages, channel posts, our own echoes,
+        # and anything from a different chat.
+        message = update.get("message")
+        if not isinstance(message, dict):
+            continue
+        chat = message.get("chat", {})
+        if str(chat.get("id")) != chat_id:
+            continue
+        text = message.get("text")
+        if not text:
+            continue
+
+        sender = message.get("from", {}) or {}
+        name = (
+            sender.get("username")
+            or sender.get("first_name")
+            or "someone"
+        )
+        # Telegram dates are unix seconds; expose as-is under "date".
+        replies.append({
+            "sender": name,
+            "subject": "",
+            "body": text,
+            "date": str(message.get("date", "")),
+        })
+
+    # Persist the new offset even if no text replies surfaced — non-text
+    # updates (stickers, edits) still advance the cursor so we don't keep
+    # re-fetching them every heartbeat.
+    if max_update_id != last:
+        _save_offset(offset_state_path, max_update_id)
+
+    return replies

--- a/state/correspondence.json
+++ b/state/correspondence.json
@@ -4,5 +4,6 @@
   "last_reply_at": null,
   "letters_sent": 0,
   "replies_received": 0,
-  "conversation_active": false
+  "conversation_active": false,
+  "telegram_offset": 0
 }


### PR DESCRIPTION
Replaces Flux's Gmail-MCP correspondence transport with a direct Telegram Bot API channel. **`write_letter()` (the dream→distilled-thought LLM call), the energy gate, and the conversation-state machine are unchanged** — only the wire moved.

## What changed
- **`src/telegram.py`** (new) — `configured()` / `send()` / `get_replies()` over stdlib `urllib.request`. **No new dependency** (urllib is stdlib; `requests` is already vendored but unused here).
- **`src/correspondence.py`** — `send_letter()` now calls `telegram.send()`; `check_mail()` calls `telegram.get_replies()`. The "recipient configured" gate became `telegram.configured()`. Heartbeat call sites (`check_mail`, `maybe_send_letter`) unchanged.
- **`state/correspondence.json`** — added `telegram_offset` field (preserves existing shape).
- **`.github/workflows/heartbeat.yml`** — pulse step now passes `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`.

## getUpdates offset handling
`getUpdates` is offset-consuming. `get_replies()` polls with `offset = last_update_id + 1` (acks everything up to `last`), then persists the highest `update_id` seen back into `state/correspondence.json` via a **read-merge-write** (never clobbers sibling fields). Non-text updates still advance the cursor so they aren't re-fetched. Verified with a mocked-`urlopen` test: chat-id filtering, text-only filtering, offset advance/consume, and field-merge all pass.

## Graceful when unconfigured
Every entrypoint is gated on `configured()` (both env vars present + non-empty). `send()` → False, `get_replies()` → []. Heartbeat call sites already wrap in try/except. An unconfigured fork never crashes the pulse.

## Behaviour change to scrutinise
Old `check_mail` required `conversation_active` before polling. New `check_mail` polls whenever Telegram is configured — so a human can **initiate** the conversation (Flux reads inbound even before it has sent a letter). This is intentional for a two-way channel; flag if you'd rather gate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)